### PR TITLE
Song Progress Interpolation

### DIFF
--- a/HomeHub/Services/AugustLockService.swift
+++ b/HomeHub/Services/AugustLockService.swift
@@ -175,7 +175,6 @@ class AugustLockService: AugustLockServiceProtocol, LoggerProtocol {
             headers: headers).responseJSON { response in
             switch response.result {
             case let .success(value):
-                self.healthy = true
                 let json = value as? [String: Any]
                 completion(json)
             case let .failure(error):

--- a/HomeHub/Services/AugustLockService.swift
+++ b/HomeHub/Services/AugustLockService.swift
@@ -52,7 +52,7 @@ class AugustLockService: AugustLockServiceProtocol, LoggerProtocol {
 
     init(delegate: AugustLockServiceDelegate? = nil) {
         self.delegate = delegate
-        pollLockState()
+//        pollLockState()
     }
 
     // MARK: - Private properties

--- a/HomeHub/Services/MusicService.swift
+++ b/HomeHub/Services/MusicService.swift
@@ -272,20 +272,23 @@ class MusicService: MusicServiceProtocol, LoggerProtocol {
             return
         }
         
-        spotify.api.authorizationManager.requestAccessAndRefreshTokens(
-            redirectURIWithQuery: url,
-            state: spotify.authorizationState
-        )
-        .receive(on: RunLoop.main)
-        .sink(receiveCompletion: { completion in
-            if case .failure(let error) = completion {
-                self.logError(error)
-            } else {
-                self.pollCurrentlyPlaying()
-            }
-        })
-        .store(in: &cancellables)
+        spotify
+            .api
+            .authorizationManager
+            .requestAccessAndRefreshTokens(
+                redirectURIWithQuery: url,
+                state: spotify.authorizationState
+            )
+            .receive(on: RunLoop.main)
+            .sink(receiveCompletion: { completion in
+                if case .failure(let error) = completion {
+                    self.logError(error)
+                } else {
+                    self.pollCurrentlyPlaying()
+                }
+            })
+            .store(in: &cancellables)
         
-        self.spotify.authorizationState = String.randomURLSafe(length: 128)
+        spotify.authorizationState = String.randomURLSafe(length: 128)
     }
 }

--- a/HomeHub/Services/MusicService.swift
+++ b/HomeHub/Services/MusicService.swift
@@ -254,7 +254,9 @@ class MusicService: MusicServiceProtocol, LoggerProtocol {
         let durationS = Float(durationMS) / 1000.0
         let percentDelta = Float(100.0 / durationS)
         let percentDeltaQuartered = (percentDelta * Float(delta)) / 100.0
-        return progress + percentDeltaQuartered
+        let interpolatedProgress = progress + percentDeltaQuartered
+
+        return interpolatedProgress > 1.0 ? 1.0 : interpolatedProgress
     }
     
     private func wait(


### PR DESCRIPTION
The song progression bar is a bit choppy since it updates once a second -- update the progression more frequently using interpolation.

### Other things
- I don't use my lock anymore so stop polling for its state
- Fixed a bug in MusicService where the `receiveCompletion(_:)` didn't have its own completion, so the caller method `loadCurrentlyPlaying(_:)` would never invoke its completion and player state polling stopped (typically after receiving an error).

Closes #2 